### PR TITLE
Create migration and associations between models

### DIFF
--- a/app/models/passenger.rb
+++ b/app/models/passenger.rb
@@ -1,2 +1,4 @@
 class Passenger < ApplicationRecord
+  has_many :rides
+  has_many :taxis, through: :rides
 end

--- a/app/models/ride.rb
+++ b/app/models/ride.rb
@@ -1,2 +1,4 @@
 class Ride < ApplicationRecord
+  belongs_to :passenger
+  belongs_to :taxi
 end

--- a/app/models/taxi.rb
+++ b/app/models/taxi.rb
@@ -1,2 +1,4 @@
 class Taxi < ApplicationRecord
+  has_many :rides
+  has_many :passengers, through: :rides
 end

--- a/db/migrate/20250820180743_add_passenger_and_taxi_ids_to_rides.rb
+++ b/db/migrate/20250820180743_add_passenger_and_taxi_ids_to_rides.rb
@@ -1,0 +1,6 @@
+class AddPassengerAndTaxiIdsToRides < ActiveRecord::Migration[7.1]
+  def change
+    add_column :rides, :passenger_id, :integer, :null => false
+    add_column :rides, :taxi_id, :integer, :null => false
+  end
+end


### PR DESCRIPTION
This pull request introduces associations between the `Passenger`, `Taxi`, and `Ride` models to establish their relationships, and adds the necessary foreign keys to the `rides` table. These changes enable each ride to be linked to both a passenger and a taxi, and allow for easy traversal between passengers, taxis, and their shared rides.

Model associations:

* Added `has_many :rides` and `has_many :taxis, through: :rides` to the `Passenger` model, allowing passengers to access their rides and associated taxis.
* Added `has_many :rides` and `has_many :passengers, through: :rides` to the `Taxi` model, enabling taxis to access their rides and associated passengers.
* Added `belongs_to :passenger` and `belongs_to :taxi` to the `Ride` model, establishing direct associations to both a passenger and a taxi for each ride.

Database migration:

* Created a migration to add `passenger_id` and `taxi_id` columns to the `rides` table, enforcing that each ride must be associated with both a passenger and a taxi.